### PR TITLE
Add option "outer" per xpath to return entire node

### DIFF
--- a/init.php
+++ b/init.php
@@ -580,9 +580,15 @@ class Feediron extends Plugin implements IHandler
 
 		foreach($xpaths as $key=>$xpath){
 			$index = 0;
-			if(is_array($xpath) && array_key_exists('index', $xpath)){
-				$index = $xpath['index'];
+			$outer = false;
+			if(is_array($xpath)){
 				$xpath = $xpath['xpath'];
+				if(array_key_exists('index', $xpath)) {
+					$index = $xpath['index'];
+				}
+				if(array_key_exists('outer', $xpath)) {
+					$outer = $xpath['outer'];
+				}				
 			}
 			$entries = $xpathdom->query('(//'.$xpath.')');   // find main DIV according to config
 
@@ -603,10 +609,12 @@ class Feediron extends Plugin implements IHandler
 
 				//render nested nodes to html
 				$inner_html = $this->getInnerHtml($basenode);
-				if (!$inner_html){
+				if (!$inner_html||$outer){
 					//if there's no nested nodes, render the node itself
+					//also return entire node if option "outer" is true
 					$inner_html = $basenode->ownerDocument->saveXML($basenode);
 				}
+				Feediron_Logger::get()->log_html(Feediron_Logger::LOG_VERBOSE, "Adding content", $inner_html);
 				array_push($htmlout, $inner_html);
 			}
 			$content = join((array_key_exists('join_element', $config)?$config['join_element']:''), $htmlout);


### PR DESCRIPTION
# Bugfix/Enhancement

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully ran tests with your changes locally?

## Proposed Changes

By default, FeedIron returns the InnerHTML of selected nodes. Sometimes in creating a recipe it is easier to build a list of nodes to be kept instead of selecting the parent element and stripping out unwanted stuff in 'cleanup'. In these cases it may be helpful to have the entire selected node returned. This commit introduces a boolean option 'outer' per xpath (same as 'index'). If set to true, the entire node is returned. The verbose log shows whatever will be added to the result.

I have considered adding the option one level up, but opted for the flexibility of having it available for specific xpaths. 

All in all, I am nowhere near being a developer, I just added the option for myself and think it may be useful to others, so bear with me!

An example recipe using this on https://www.computerworld.ch/Computerworld-Newsfeed.html is:
    "computerworld.ch": {
        "type": "xpath",
        "xpath": [
            {
                "xpath": "div[@id='dachzeile']",
                "outer": true
            },
            {
                "xpath": "*[@id='headline']",
                "outer": true
            },
            {
                "xpath": "div[@id='vorspann']",
                "outer": true
            },
            {
                "xpath": "div[contains(@class,'aufmacherbild')]",
                "outer": true
            },
            {
                "xpath": "div[@id='text']",
                "outer": true
            }
        ],
        "cleanup": [
            "nav"
        ],
        "reformat": [
            {
                "type": "regex",
                "pattern": "%(.*)%",
                "replace": "$1?ganzseitig=1"
            }
        ],
        "modify": [
            {
                "type": "regex",
                "pattern": "%(\\<img src=\\\")(.*\\>)%m",
                "replace": "$1https:\/\/www.computerworld.ch$2"
            },
            {
                "type": "regex",
                "pattern": "%(\\<source srcset=\\\")(.*\\>)%m",
                "replace": "$1https:\/\/www.computerworld.ch$2"
            }
        ]
    }